### PR TITLE
Pass captions into v15 prediction features

### DIFF
--- a/src/app/api/bulk-download/predict/route.ts
+++ b/src/app/api/bulk-download/predict/route.ts
@@ -202,6 +202,10 @@ export async function POST(request: NextRequest) {
         transcript: resolvedTranscript,
         niche: body.niche || undefined,
         followerCount,
+        // Phase 1: forward the captured caption/description so hashtag-derived
+        // features (hashtag_count, has_fyp_hashtag, meta_has_viral_hashtag) and
+        // caption emoji/text features populate instead of always defaulting to 0/false.
+        caption: item.description || undefined,
       });
     } catch (pipelineErr: any) {
       // Mark run as failed

--- a/src/app/api/bulk-download/route.ts
+++ b/src/app/api/bulk-download/route.ts
@@ -335,6 +335,9 @@ async function processDownloadJob(jobId: string) {
               local_path: result.localPath,
               file_size_bytes: result.fileSizeBytes,
               duration_seconds: result.durationSeconds,
+              // Caption/description ONLY — pre-publication content for hashtag/caption
+              // features (Phase 1 forwarding reads item.description). NOT a metric.
+              description: result.description ?? null,
               downloaded_at: new Date().toISOString()
               // NO: author_username, views, likes, comments, shares
               // Those would contaminate prediction testing

--- a/src/app/api/kai/predict/route.ts
+++ b/src/app/api/kai/predict/route.ts
@@ -69,6 +69,7 @@ export async function POST(request: NextRequest) {
     let videoPath: string | null = null;
     let apifyTranscript: string | null = null;
     let apifyRawItem: any = null; // Preserved for post-prediction labeling
+    let resolvedCaption: string | undefined = undefined; // Phase 1: caption/hashtags for feature extraction
 
     // Step 1: Save MP4 file (if uploaded)
     if (videoFile) {
@@ -111,6 +112,19 @@ export async function POST(request: NextRequest) {
             apifyRawItem = items[0]; // Preserve raw item for post-prediction labeling
             const normalized = normalizeApifyItem(items[0]);
             const cdnUrl = normalized.videoUrl || normalized.downloadAddr;
+
+            // Phase 1: capture caption/hashtags so hashtag-derived features
+            // (hashtag_count, has_fyp_hashtag, meta_has_viral_hashtag) populate.
+            // Posted descriptions usually carry hashtags inline in `text`; if not,
+            // append the structured `hashtags` array so the regex still finds them.
+            {
+              const txt = normalized.text || '';
+              const tags = (normalized.hashtags || []).map((h: string) => `#${h}`);
+              resolvedCaption =
+                tags.length && !/#/.test(txt)
+                  ? `${txt} ${tags.join(' ')}`.trim()
+                  : txt || undefined;
+            }
 
             if (cdnUrl) {
               const videoDir = join(process.cwd(), 'data', 'raw_videos');
@@ -271,6 +285,9 @@ export async function POST(request: NextRequest) {
       transcript: resolvedTranscript,
       niche: niche || undefined,
       followerCount,
+      // Phase 1: forward the captured caption/description (Apify scrape path) so
+      // hashtag/caption-derived features populate instead of defaulting to 0/false.
+      caption: resolvedCaption,
     });
 
     const totalLatency = Date.now() - startTime;

--- a/src/app/api/kai/predict/route.ts
+++ b/src/app/api/kai/predict/route.ts
@@ -169,6 +169,12 @@ export async function POST(request: NextRequest) {
             videoPath = downloadResult.localPath;
             storagePath = downloadResult.localPath.replace(process.cwd() + '\\', '').replace(process.cwd() + '/', '');
 
+            // Phase 1B parity: use the downloader-captured caption/description for
+            // hashtag/caption features when no higher-priority caption (Apify) is set.
+            if (!resolvedCaption && downloadResult.description) {
+              resolvedCaption = downloadResult.description;
+            }
+
             console.log(`✅ TikTok video downloaded successfully: ${videoPath}`);
           } else {
             console.error(`❌ TikTok download FAILED: ${downloadResult.error}`);

--- a/src/lib/services/tiktok-downloader.ts
+++ b/src/lib/services/tiktok-downloader.ts
@@ -26,7 +26,10 @@ export interface DownloadResult {
   fileSizeBytes?: number;
   durationSeconds?: number;
   error?: string;
-  // NO metadata field - we don't want views, likes, etc.
+  // Caption/description ONLY — pre-publication content used for hashtag/caption
+  // features (v15 uses hashtags by design). This is NOT a performance metric;
+  // we still never save views/likes/comments/shares.
+  description?: string;
 }
 
 export interface DownloadProgress {
@@ -223,11 +226,27 @@ export class TikTokDownloader {
       // Get file stats only
       const stats = await stat(localPath);
 
-      // Return RAW file info only - NO metrics
+      // Best-effort, non-fatal caption/description fetch (separate --print call
+      // so the proven download command above is untouched). Caption/hashtags are
+      // pre-publication content, NOT a performance metric. Failure is ignored.
+      let description: string | undefined;
+      try {
+        const { stdout } = await execAsync(
+          `yt-dlp --skip-download --print "%(description)s" "${url}"`,
+          { timeout: 15000, maxBuffer: 1024 * 1024 },
+        );
+        const text = (stdout || '').trim();
+        if (text && text !== 'NA') description = text;
+      } catch (metaErr: any) {
+        console.warn('[TikTok Downloader] caption fetch skipped (non-fatal):', metaErr.message);
+      }
+
+      // Return RAW file info only - NO metrics (caption is content, not a metric)
       return {
         success: true,
         localPath,
-        fileSizeBytes: stats.size
+        fileSizeBytes: stats.size,
+        description
         // NO metadata, views, likes, etc.
       };
 
@@ -283,12 +302,20 @@ export class TikTokDownloader {
 
       const stats = await stat(localPath);
 
+      // Caption/description only (TikWM exposes it as `title`). Already in scope —
+      // no extra request. NOT a performance metric.
+      const description =
+        typeof data.data.title === 'string' && data.data.title.trim().length > 0
+          ? data.data.title.trim()
+          : undefined;
+
       // Return RAW file info only - NO metrics (ignore data.data.play_count, etc.)
       return {
         success: true,
         localPath,
         fileSizeBytes: stats.size,
-        durationSeconds: data.data.duration || undefined
+        durationSeconds: data.data.duration || undefined,
+        description
         // NO: views, likes, comments, shares, author info
       };
 


### PR DESCRIPTION
Phase 1: forward caption/description into runVpsPipelineV2 from the bulk-download and kai/upload-test predict routes so hashtag/caption features (hashtag_count, has_fyp_hashtag, meta_has_viral_hashtag, emoji) populate instead of always defaulting to 0/false.

Phase 1B: capture the TikTok caption during bulk download (yt-dlp best-effort --print, TikWM title fallback) and save it to bulk_download_items.description. Caption is pre-publication content, not a performance metric; views/likes/comments/shares are still never saved.

### PR Checklist

- [ ] ✅ No ryOS code/assets copied; behavior-only mirroring.
- [ ] Tests added/updated where applicable
- [ ] Accessibility reviewed for new interactions
- [ ] Performance considerations (memoization, avoids unnecessary re-renders)

### Summary

Describe what this PR changes and which components/areas are affected.


