### PR TITLE
Persist bulk transcript telemetry

### DIFF
--- a/src/app/api/bulk-download/predict/route.ts
+++ b/src/app/api/bulk-download/predict/route.ts
@@ -234,6 +234,11 @@ export async function POST(request: NextRequest) {
         components_used: ['xgboost-virality-ml'],
         latency_ms_total: v2Result.extraction_time_ms + v2Result.inference_time_ms,
         score_version: 'vps-v2-xgboost-sole',
+        // Telemetry only — persist transcript provenance so audits read the
+        // real transcript state instead of the unwritten legacy default.
+        // Does not affect prediction logic, scoring, or extracted features.
+        transcription_source: transcriptSource,
+        resolved_transcript_length: resolvedTranscript?.length || 0,
         raw_result: {
           vps: v2Result.vps,
           raw_prediction: v2Result.raw_prediction,


### PR DESCRIPTION
Persist transcript provenance (transcription_source, resolved_transcript_length) in the bulk-download prediction_runs finalize update so audits read real transcript state instead of the unwritten legacy default. Telemetry only — no change to prediction logic, model routing, scoring, extracted features, or schema.

### PR Checklist

- [ ] ✅ No ryOS code/assets copied; behavior-only mirroring.
- [ ] Tests added/updated where applicable
- [ ] Accessibility reviewed for new interactions
- [ ] Performance considerations (memoization, avoids unnecessary re-renders)

### Summary

Describe what this PR changes and which components/areas are affected.


